### PR TITLE
fix example usage comment

### DIFF
--- a/include/cmocka.h
+++ b/include/cmocka.h
@@ -1488,7 +1488,7 @@ static inline void _unit_test_dummy(void **state) {
  * @code
  * static int setup(void **state) {
  *      int *answer = malloc(sizeof(int));
- *      if (*answer == NULL) {
+ *      if (answer == NULL) {
  *          return -1;
  *      }
  *      *answer = 42;


### PR DESCRIPTION
dereferenced value of pointer compared against null to check malloc
success instead of actual pointer. changed so it doesn't cause further
confusion if anyone wants to use the provided example